### PR TITLE
Enhance video board with Vimeo URL support and category navigation

### DIFF
--- a/theme/nero/skin/board/youtube/list.skin.php
+++ b/theme/nero/skin/board/youtube/list.skin.php
@@ -2,6 +2,13 @@
 if (!defined('_GNUBOARD_')) exit; // 개별 페이지 접근 불가
 include_once(G5_LIB_PATH.'/thumbnail.lib.php');
 
+function get_vimeo_id_from_url($url){
+    if(preg_match('/vimeo\.com\/(?:video\/)?([0-9]+)/', $url, $m)) return $m[1];
+    if(preg_match('/^[0-9]+$/', trim($url))) return trim($url);
+    return '';
+}
+
+
 function get_paging2($write_pages, $cur_page, $total_page, $url, $add="")
 {
 	global $config;
@@ -94,14 +101,25 @@ add_stylesheet('<link rel="stylesheet" href="'.$board_skin_url.'/wzappend.css">'
 	<div class="stitle wow fadeInup"  data-wow-duration="1s">
     <h2  class="titleM"><?php echo $sNum?></h2>
   </div>
+<?php if ($is_category) { ?>
+<nav id="bo_cate" style="margin:20px 0px;">
+    <h2><?php echo $board['bo_subject'] ?> 카테고리</h2>
+    <ul id="bo_cate_ul">
+        <?php echo $category_option ?>
+    </ul>
+</nav>
+<?php } ?>
 
-	<div class="you_big">
-		<div class="embed-vimeo">
-		<iframe width="100%" height="100%" src="https://player.vimeo.com/video/<?=$list[0]['wr_link1']?>" title="Vimeo video player" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
-		</div>
-	</div>
+	<?php $first_video_id = isset($list[0]['wr_link1']) ? get_vimeo_id_from_url($list[0]['wr_link1']) : ''; ?>
+<?php if($first_video_id){ ?>
+<div class="you_big">
+                <div class="embed-vimeo">
+                <iframe width="100%" height="100%" src="https://player.vimeo.com/video/<?=$first_video_id?>" title="Vimeo video player" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
+                </div>
+        </div>
+<?php } ?>
 
-		<form name="fboardlist"  id="fboardlist" action="<?php echo G5_BBS_URL; ?>/board_list_update.php" onsubmit="return fboardlist_submit(this);" method="post">
+                <form name="fboardlist"  id="fboardlist" action="<?php echo G5_BBS_URL; ?>/board_list_update.php" onsubmit="return fboardlist_submit(this);" method="post">
 		<input type="hidden" name="bo_table" value="<?php echo $bo_table ?>">
 		<input type="hidden" name="sfl" value="<?php echo $sfl ?>">
 		<input type="hidden" name="stx" value="<?php echo $stx ?>">
@@ -153,38 +171,30 @@ add_stylesheet('<link rel="stylesheet" href="'.$board_skin_url.'/wzappend.css">'
 
 
 		<div class="youtube">
-		<!-- 게시판 카테고리 시작 { -->
-		<?php if ($is_category) { ?>
-		<nav id="bo_cate" style="margin:20px 0px;">
-				<h2><?php echo $board['bo_subject'] ?> 카테고리</h2>
-				<ul id="bo_cate_ul">
-						<?php echo $category_option ?>
-				</ul>
-		</nav>
-		<?php } ?>
-		<!-- } 게시판 카테고리 끝 -->
-
+		
 			<div class="you_wrap">
 				<?php for ($i=0; $i<count($list); $i++) {
 
-						$classes = array();
+                                                $classes = array();
 
-						$classes[] = 'gall_li';
-						$classes[] = 'col-gn-'.$bo_gallery_cols;
+                                                $classes[] = 'gall_li';
+                                                $classes[] = 'col-gn-'.$bo_gallery_cols;
 
-						if( $i && ($i % $bo_gallery_cols == 0) ){
-								$classes[] = 'box_clear';
-						}
+                                                if( $i && ($i % $bo_gallery_cols == 0) ){
+                                                                $classes[] = 'box_clear';
+                                                }
 
-						if( $wr_id && $wr_id == $list[$i]['wr_id'] ){
-								$classes[] = 'gall_now';
-						}
+                                                if( $wr_id && $wr_id == $list[$i]['wr_id'] ){
+                                                                $classes[] = 'gall_now';
+                                                }
 
-						$line_height_style = ($board['bo_gallery_height'] > 0) ? 'line-height:'.$board['bo_gallery_height'].'px' : '';
-				 ?>
-				<div class="you_box" data-value="<?=$list[$i]['wr_link1']?>">
+                                                $line_height_style = ($board['bo_gallery_height'] > 0) ? 'line-height:'.$board['bo_gallery_height'].'px' : '';
+                                $video_id = get_vimeo_id_from_url($list[$i]['wr_link1']);
+                                 ?>
+                                <div class="you_box" data-value="<?=$video_id?>">
+
 					<div class="you_thum">
-						<img src="https://vumbnail.com/<?=$list[$i]['wr_link1']?>.jpg" alt="">
+						<img src="https://vumbnail.com/<?=$video_id?>.jpg" alt="">
 						<span class="you_thum_bg"><img src="<?php echo G5_THEME_URL ?>/img/you_thum_bg.png" alt=""></span>
 						<div class="playbtn_wrap"><div class="playbtn"><i class="fa fa-play" aria-hidden="true"></i></div></div>
 						<div class="gall_chk chk_box">
@@ -222,7 +232,7 @@ add_stylesheet('<link rel="stylesheet" href="'.$board_skin_url.'/wzappend.css">'
 
 							<a href="javascript:void(0)" class="vimeo_view">간편보기</a>
 							<a href="<?php echo $list[$i]['href'] ?>" class="vimeo_view">게시글 보기</a>
-							<a href="https://vimeo.com/<?=$list[$i]['wr_link1']?>" target=_blank>비메오</a>
+							<a href="https://vimeo.com/<?=$video_id?>" target=_blank>비메오</a>
 						</div>
 					</div>
 				</div>

--- a/theme/nero/skin/board/youtube/style.css
+++ b/theme/nero/skin/board/youtube/style.css
@@ -485,6 +485,24 @@ button.btn_frmline span{font-size: 12px;}
     height: 100%;
 }
 
+.video-wrap {
+  position: relative;
+  padding-bottom: 56.25%;
+  margin: 50px auto 30px;
+  height: 0;
+  overflow: hidden;
+}
+
+.video-wrap iframe,
+.video-wrap object,
+.video-wrap embed {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
 .you_wrap {
   display: flex;
   justify-content: space-between;
@@ -616,6 +634,7 @@ button.btn_frmline span{font-size: 12px;}
   /*.page span {width:30px;height:30px;line-height:30px;}*/
   .page{display:none;}
   .mpage{display:flex;}
+  .video-wrap{margin:30px auto;}
 }
 
 @media screen and (max-width: 460px) {

--- a/theme/nero/skin/board/youtube/view.skin.php
+++ b/theme/nero/skin/board/youtube/view.skin.php
@@ -97,14 +97,8 @@ if($view['wr_link1']) {
 }
 if($video_id){
 ?>
-  <style>
-  .video-wrap {position:relative;padding-bottom:56.25%;margin:0 auto;height:0; overflow:hidden; margin-bottom: 30px; margin-top: 50px;}
-  .video-wrap iframe,
-  .video-wrap object,
-  .video-wrap embed {position:absolute; top:0; left:0; width:100%; height:100%;}
-  </style>
   <div class="video-wrap">
-     <iframe id="video" width="100%" height="315" src="https://player.vimeo.com/video/<?=$video_id?>" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
+     <iframe id="video" width="100%" height="100%" src="https://player.vimeo.com/video/<?=$video_id?>" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
   </div>
 <?php } ?>
 

--- a/theme/nero/skin/board/youtube/view.skin.php
+++ b/theme/nero/skin/board/youtube/view.skin.php
@@ -86,17 +86,27 @@ add_stylesheet('<link rel="stylesheet" href="'.$board_skin_url.'/style.css">', 0
 
     <section id="bo_v_atc">
         <h2 id="bo_v_atc_title">본문</h2>
-        <?php if($view['wr_link1']){?>
-          <style>
-          .video-wrap {position:relative;padding-bottom:56.25%;margin:0 auto;height:0; overflow:hidden; margin-bottom: 30px; margin-top: 50px;}
-          .video-wrap iframe,
-          .video-wrap object,
-          .video-wrap embed {position:absolute; top:0; left:0; width:100%; height:100%;}
-          </style>
-          <div class="video-wrap">
-             <iframe id="video" width="100%" height="315" src="https://player.vimeo.com/video/<?=$view['wr_link1']?>" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
-          </div>
-       <?php }?>
+        <?php
+$video_id = '';
+if($view['wr_link1']) {
+    if(preg_match('/vimeo\.com\/(?:video\/)?([0-9]+)/', $view['wr_link1'], $matches)) {
+        $video_id = $matches[1];
+    } elseif(preg_match('/^[0-9]+$/', trim($view['wr_link1']))) {
+        $video_id = trim($view['wr_link1']);
+    }
+}
+if($video_id){
+?>
+  <style>
+  .video-wrap {position:relative;padding-bottom:56.25%;margin:0 auto;height:0; overflow:hidden; margin-bottom: 30px; margin-top: 50px;}
+  .video-wrap iframe,
+  .video-wrap object,
+  .video-wrap embed {position:absolute; top:0; left:0; width:100%; height:100%;}
+  </style>
+  <div class="video-wrap">
+     <iframe id="video" width="100%" height="315" src="https://player.vimeo.com/video/<?=$video_id?>" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
+  </div>
+<?php } ?>
 
         <?php
         // 파일 출력

--- a/theme/nero/skin/board/youtube/write.skin.php
+++ b/theme/nero/skin/board/youtube/write.skin.php
@@ -128,12 +128,12 @@ add_stylesheet('<link rel="stylesheet" href="'.$board_skin_url.'/style.css">', 0
 
     </div>
 <?php $i=1; ?>
-<label for="" class="bwcon_title you_exinfo">링크 #1 비메오 아이디 작성 <span>https://vimeo.com/<strong>123456789</strong></span></label>
+<label for="" class="bwcon_title you_exinfo">링크 #1 비메오 URL 또는 아이디 작성 <span>예: https://vimeo.com/<strong>123456789</strong></span></label>
       <div class="write_wrap">
       <?php for ($i=1; $is_link && $i<=G5_LINK_COUNT; $i++) { ?>
         <div class="write_box">
           <label for="wr_link<?php echo $i ?>" class="bwcon_title">링크  #<?php echo $i ?></label>
-          <div class="write_content"><input type="text" name="wr_link<?php echo $i ?>" value="<?php if($w=="u"){ echo $write['wr_link'.$i]; } ?>" id="wr_link<?php echo $i ?>" class=""></div>
+          <div class="write_content"><input type="text" name="wr_link<?php echo $i ?>" value="<?php if($w=="u"){ echo $write['wr_link'.$i]; } ?>" id="wr_link<?php echo $i ?>" class="" placeholder="Vimeo URL 또는 ID"></div>
         </div>
       <?php } ?>
       </div>


### PR DESCRIPTION
## Summary
- Allow Vimeo URLs or IDs when submitting videos and embed them automatically
- Surface board categories before the video list so users can filter early
- Normalize Vimeo IDs across list and view templates for consistent playback

## Testing
- `php -l theme/nero/skin/board/youtube/write.skin.php`
- `php -l theme/nero/skin/board/youtube/view.skin.php`
- `php -l theme/nero/skin/board/youtube/list.skin.php`


------
https://chatgpt.com/codex/tasks/task_e_689969a4c7308325abdac9ebe4d9d71d